### PR TITLE
Feat/ECO-3370-app-boilerplate-updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "marketplace-app-boilerplate",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "marketplace-app-boilerplate",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "dependencies": {
         "@contentstack/app-sdk": "^1.5.0",
         "@types/jest": "^29.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marketplace-app-boilerplate",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "files": [
     "dist"

--- a/rte/src/common/locales/en-us/index.ts
+++ b/rte/src/common/locales/en-us/index.ts
@@ -4,7 +4,7 @@ const localeTexts = {
     description: "Your new RTE plugin can be found on the toolbar above.",
     body: "You can also find your plugin on the <strong>hoveringToolbar</strong> by selecting any text. Try selecting me.",
     button: {
-      learnMore: "Learn more",
+      text: "Learn more",
     },
   },
 };

--- a/rte/src/index.css
+++ b/rte/src/index.css
@@ -153,7 +153,7 @@ h4 {
 }
 
 .dashboard-container {
-  padding: 8px 0px 8px 0px;
+  padding: 8px 0px;
 }
 
 .dashboard-icon {

--- a/rte/src/plugin.tsx
+++ b/rte/src/plugin.tsx
@@ -30,7 +30,7 @@ export default ContentstackSDK.init().then(async (sdk) => {
           </div>
           <div className="app-component-content">
             <p>{parse(localeTexts.RTE.body)}</p>
-            <a href="/">{localeTexts.RTE.button.learnMore}</a>
+            <a href="/">{localeTexts.RTE.button.text}</a>
           </div>
         </div>
       );

--- a/src/common/locales/en-us/index.ts
+++ b/src/common/locales/en-us/index.ts
@@ -3,56 +3,64 @@ const localeTexts = {
     title: "404: Not Found",
     body: "The link you tried to access doesn't seem to exist. <br />Please verify and enter the correct URL.",
     button: {
-      learnMore: "Learn more",
+      text: "Learn more",
+      url: "https://www.contentstack.com/docs/developers/developer-hub/about-ui-locations/",
     },
   },
   AssetSidebarWidget: {
     title: "Asset Sidebar Widget",
     body: "This is the location that contains your Asset Sidebar Widget. <br />Create your new app now!",
     button: {
-      learnMore: "Learn more",
+      text: "Learn more",
+      url: "https://www.contentstack.com/docs/developers/developer-hub/asset-sidebar-location/",
     },
   },
   ConfigScreen: {
     title: "App Configuration",
     body: "This is the location that contains your App Configuration. <br />Create your new app now!",
     button: {
-      learnMore: "Learn more",
+      text: "Learn more",
+      url: "https://www.contentstack.com/docs/developers/developer-hub/app-config-location/",
     },
   },
   CustomField: {
     title: "Custom Field",
     body: "This is the location that contains your Custom Field. <br />Create your new app now!",
     button: {
-      learnMore: "Learn more",
+      text: "Learn more",
+      url: "https://www.contentstack.com/docs/developers/developer-hub/custom-field-location/",
     },
   },
   DashboardWidget: {
     title: "Dashboard Widget",
     body: "This is the location that contains your Dashboard Widget. <br />Create your new app now!",
     button: {
-      learnMore: "Learn more",
+      text: "Learn more",
+      url: "https://www.contentstack.com/docs/developers/developer-hub/dashboard-location/",
     },
   },
   SidebarWidget: {
     title: "Sidebar Widget",
     body: "This is the location that contains your Entry Sidebar Widget. <br />Create your new app now!",
     button: {
-      learnMore: "Learn more",
+      text: "Learn more",
+      url: "https://www.contentstack.com/docs/developers/developer-hub/sidebar-location/",
     },
   },
   FullPage: {
     title: "Full Page App",
     body: "This is the location that contains your Full Page app. <br />Create your new app now!",
     button: {
-      learnMore: "Learn more",
+      text: "Learn more",
+      url: "https://www.contentstack.com/docs/developers/developer-hub/full-page-location/",
     },
   },
   FieldModifier: {
     title: "Field Modifier App",
     body: "This is the location that contains your Field Modifier app. <br />Create your new app now!",
     button: {
-      learnMore: "Learn more",
+      text: "Learn more",
+      url: "https://www.contentstack.com/docs/developers/developer-hub/field-modifier-location/",
     },
   },
   AppFailed: {
@@ -60,7 +68,8 @@ const localeTexts = {
     Message2: "Please navigate to Your Stack in Contentstack where you just installed the Application ",
     body: "For Assistance, please reach out to us at support@contentstack.com",
     button: {
-      learnMore: "Learn more",
+      text: "Learn more",
+      url: "https://www.contentstack.com/docs/developers/developer-hub/marketplace-app-boilerplate/",
     },
   },
 };

--- a/src/common/locales/en-us/index.ts
+++ b/src/common/locales/en-us/index.ts
@@ -55,6 +55,14 @@ const localeTexts = {
       learnMore: "Learn more",
     },
   },
+  AppFailed: {
+    Message1: "The App was loaded outside Contentstack Dashboard.",
+    Message2: "Please navigate to Your Stack in Contentstack where you just installed the Application ",
+    body: "For Assistance, please reach out to us at support@contentstack.com",
+    button: {
+      learnMore: "Learn more",
+    },
+  },
 };
 
 export default localeTexts;

--- a/src/components/AppFailed.tsx
+++ b/src/components/AppFailed.tsx
@@ -6,7 +6,7 @@ import localeTexts from "../common/locales/en-us";
  */
 export const AppFailed = () => {
   const handleLearnMoreClick = () => {
-    window.open("https://www.contentstack.com/docs/developers/developer-hub/marketplace-app-boilerplate/", "_blank");
+    window.open(localeTexts.AppFailed.button.url, "_blank");
   };
   return (
     <div className="app-failed-container">
@@ -33,7 +33,7 @@ export const AppFailed = () => {
                 d="M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z"
                 clipRule="evenodd"></path>
             </svg>
-            Learn More
+            {localeTexts.AppFailed.button.text}
           </button>
         </div>
       </div>

--- a/src/components/AppFailed.tsx
+++ b/src/components/AppFailed.tsx
@@ -1,8 +1,13 @@
+import localeTexts from "../common/locales/en-us";
+
 /**
  * AppFailed component.
  * This components will be rendered if the App fails to initialize.( ContentStack SDK)
  */
 export const AppFailed = () => {
+  const handleLearnMoreClick = () => {
+    window.open("https://www.contentstack.com/docs/developers/developer-hub/marketplace-app-boilerplate/", "_blank");
+  };
   return (
     <div className="app-failed-container">
       <div className="app-component-container" role="alert">
@@ -13,11 +18,14 @@ export const AppFailed = () => {
               d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
               clipRule="evenodd"></path>
           </svg>
-          <h3>Something went wrong. Please try refreshing the page.</h3>
+          <h3>
+            {localeTexts.AppFailed.Message1} <br />
+            {localeTexts.AppFailed.Message2}
+          </h3>
         </div>
-        <div className="app-text">If the issue continues, please reach out to us at support@contentstack.com</div>
+        <div className="app-text">{localeTexts.AppFailed.body}</div>
         <div className="secondary-app-container">
-          <button type="button">
+          <button type="button" onClick={handleLearnMoreClick}>
             <svg className="app-learn-more" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
               <path d="M10 12a2 2 0 100-4 2 2 0 000 4z"></path>
               <path
@@ -25,7 +33,7 @@ export const AppFailed = () => {
                 d="M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z"
                 clipRule="evenodd"></path>
             </svg>
-            Learn more
+            Learn More
           </button>
         </div>
       </div>

--- a/src/containers/404/404.tsx
+++ b/src/containers/404/404.tsx
@@ -11,8 +11,8 @@ const PageNotFound = () => {
           <a
             target="_blank"
             rel="noreferrer"
-            href="https://www.contentstack.com/docs/developers/developer-hub/about-ui-locations/">
-            {localeTexts[404].button.learnMore}
+            href={localeTexts[404].button.url}>
+            {localeTexts[404].button.text}
           </a>
         </div>
       </div>

--- a/src/containers/AssetSidebarWidget/AssetSidebar.tsx
+++ b/src/containers/AssetSidebarWidget/AssetSidebar.tsx
@@ -15,8 +15,8 @@ const AssetSidebarExtension = () => {
           <a
             target="_blank"
             rel="noreferrer"
-            href="https://www.contentstack.com/docs/developers/developer-hub/asset-sidebar-location/">
-            {localeTexts.AssetSidebarWidget.button.learnMore}
+            href={localeTexts.AssetSidebarWidget.button.url}>
+            {localeTexts.AssetSidebarWidget.button.text}
           </a>
         </div>
       </div>

--- a/src/containers/ConfigScreen/AppConfiguration.tsx
+++ b/src/containers/ConfigScreen/AppConfiguration.tsx
@@ -15,8 +15,8 @@ const AppConfigurationExtension = () => {
           <a
             target="_blank"
             rel="noreferrer"
-            href="https://www.contentstack.com/docs/developers/developer-hub/app-config-location/">
-            {localeTexts.ConfigScreen.button.learnMore}
+            href={localeTexts.ConfigScreen.button.url}>
+            {localeTexts.ConfigScreen.button.text}
           </a>
         </div>
       </div>

--- a/src/containers/CustomField/CustomField.tsx
+++ b/src/containers/CustomField/CustomField.tsx
@@ -15,8 +15,8 @@ const CustomFieldExtension = () => {
           <a
             target="_blank"
             rel="noreferrer"
-            href="https://www.contentstack.com/docs/developers/developer-hub/custom-field-location/">
-            {localeTexts.CustomField.button.learnMore}
+            href={localeTexts.CustomField.button.url}>
+            {localeTexts.CustomField.button.text}
           </a>
         </div>
       </div>

--- a/src/containers/DashboardWidget/StackDashboard.tsx
+++ b/src/containers/DashboardWidget/StackDashboard.tsx
@@ -15,8 +15,8 @@ const StackDashboardExtension = () => {
           <a
             target="_blank"
             rel="noreferrer"
-            href="https://www.contentstack.com/docs/developers/developer-hub/dashboard-location/">
-            {localeTexts.DashboardWidget.button.learnMore}
+            href={localeTexts.DashboardWidget.button.url}>
+            {localeTexts.DashboardWidget.button.text}
           </a>
         </div>
       </div>

--- a/src/containers/FieldModifier/FieldModifier.tsx
+++ b/src/containers/FieldModifier/FieldModifier.tsx
@@ -15,8 +15,8 @@ const FieldModifierExtension = () => {
           <a
             target="_blank"
             rel="noreferrer"
-            href="https://www.contentstack.com/docs/developers/developer-hub/field-modifier-location/">
-            {localeTexts.FieldModifier.button.learnMore}
+            href={localeTexts.FieldModifier.button.url}>
+            {localeTexts.FieldModifier.button.text}
           </a>
         </div>
       </div>

--- a/src/containers/FullPage/FullPage.tsx
+++ b/src/containers/FullPage/FullPage.tsx
@@ -15,8 +15,8 @@ const FullPageExtension = () => {
           <a
             target="_blank"
             rel="noreferrer"
-            href="https://www.contentstack.com/docs/developers/developer-hub/full-page-location/">
-            {localeTexts.FullPage.button.learnMore}
+            href={localeTexts.FullPage.button.url}>
+            {localeTexts.FullPage.button.text}
           </a>
         </div>
       </div>

--- a/src/containers/SidebarWidget/EntrySidebar.tsx
+++ b/src/containers/SidebarWidget/EntrySidebar.tsx
@@ -15,8 +15,8 @@ const EntrySidebarExtension = () => {
           <a
             target="_blank"
             rel="noreferrer"
-            href="https://www.contentstack.com/docs/developers/developer-hub/sidebar-location/">
-            {localeTexts.SidebarWidget.button.learnMore}
+            href={localeTexts.SidebarWidget.button.url}>
+            {localeTexts.SidebarWidget.button.text}
           </a>
         </div>
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -143,7 +143,7 @@ a {
 }
 
 .dashboard-container {
-  padding: 8px 0px 8px 0px;
+  padding: 8px 0;
 }
 
 .dashboard-icon {

--- a/src/index.css
+++ b/src/index.css
@@ -262,6 +262,7 @@ a {
   text-align: center;
   align-items: center;
   border-radius: 0.5rem;
+  cursor: pointer;
 }
 
 .app-learn-more {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
+import { HashRouter } from "react-router-dom";
 import reportWebVitals from "./reportWebVitals";
 import App from "./containers/App/App";
 import "./index.css";
@@ -8,9 +8,9 @@ import "./index.css";
 const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
 root.render(
   <React.StrictMode>
-    <BrowserRouter>
+    <HashRouter>
       <App />
-    </BrowserRouter>
+    </HashRouter>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
- updated router from browser router to hash
- Added Proper guidance message when app is loaded outside Contentstack and learn more button link updated
<img width="1728" alt="image" src="https://github.com/contentstack/marketplace-app-boilerplate/assets/115449840/8ab2fa21-92bf-412b-b63f-07410a1cf557">

- CSS updated in RTE/index to use shorthand properties